### PR TITLE
Add timeout to callbacks

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
+        include-prerelease: True
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,13 +16,12 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
-        include-prerelease: True
+        dotnet-version: 5.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build
+      run: dotnet test --no-build --blame-hang-timeout 5m --blame-hang-dump-type full
     - name: Pack
       run: dotnet pack

--- a/Rido.IoTHubClient.Tests/Rido.IoTHubClient.Tests.csproj
+++ b/Rido.IoTHubClient.Tests/Rido.IoTHubClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Rido.IoTHubClient.Tests/Rido.IoTHubClient.Tests.csproj
+++ b/Rido.IoTHubClient.Tests/Rido.IoTHubClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Rido.IoTHubClient/DpsClient.cs
+++ b/Rido.IoTHubClient/DpsClient.cs
@@ -80,7 +80,7 @@ namespace Rido.IoTHubClient
             {
                 await mqttClient.DisconnectAsync();
             }
-            var tcs = new TaskCompletionSource<DpsStatus>();
+            var tcs = new TaskCompletionSource<DpsStatus>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var resource = $"{idScope}/registrations/{registrationId}";
             var username = $"{resource}/api-version=2019-03-31";
@@ -103,7 +103,7 @@ namespace Rido.IoTHubClient
             var suback = await mqttClient.SubscribeAsync("$dps/registrations/res/#");
             suback.Items.ToList().ForEach(x => Trace.TraceWarning($"+ {x.TopicFilter.Topic} {x.ResultCode}"));
             await ConfigureDPSFlowAsync(registrationId, modelId, tcs);
-            return tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(5)).Result;
+            return await tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(5));
 
         }
 

--- a/Rido.IoTHubClient/DpsClient.cs
+++ b/Rido.IoTHubClient/DpsClient.cs
@@ -103,7 +103,7 @@ namespace Rido.IoTHubClient
             var suback = await mqttClient.SubscribeAsync("$dps/registrations/res/#");
             suback.Items.ToList().ForEach(x => Trace.TraceWarning($"+ {x.TopicFilter.Topic} {x.ResultCode}"));
             await ConfigureDPSFlowAsync(registrationId, modelId, tcs);
-            return tcs.Task.Result;
+            return tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(50)).Result;
 
         }
 

--- a/Rido.IoTHubClient/DpsClient.cs
+++ b/Rido.IoTHubClient/DpsClient.cs
@@ -103,7 +103,7 @@ namespace Rido.IoTHubClient
             var suback = await mqttClient.SubscribeAsync("$dps/registrations/res/#");
             suback.Items.ToList().ForEach(x => Trace.TraceWarning($"+ {x.TopicFilter.Topic} {x.ResultCode}"));
             await ConfigureDPSFlowAsync(registrationId, modelId, tcs);
-            return tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(50)).Result;
+            return tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(5)).Result;
 
         }
 

--- a/Rido.IoTHubClient/HubMqttClient.cs
+++ b/Rido.IoTHubClient/HubMqttClient.cs
@@ -236,7 +236,7 @@ namespace Rido.IoTHubClient
 
         public async Task<string> GetTwinAsync()
         {
-            var tcs = new TaskCompletionSource<string>();
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             var puback = await PublishAsync($"$iothub/twin/GET/?$rid={lastRid++}", string.Empty);
             if (puback?.ReasonCode == MqttClientPublishReasonCode.Success)
             {
@@ -246,12 +246,12 @@ namespace Rido.IoTHubClient
             {
                 twin_cb = s => tcs.TrySetException(new ApplicationException($"Error '{puback.ReasonCode}' publishing twin GET: {s}"));
             }
-            return tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(twinOperationTimeoutSeconds)).Result;
+            return await tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(twinOperationTimeoutSeconds));
         }
 
         public async Task<int> UpdateTwinAsync(object payload)
         {
-            var tcs = new TaskCompletionSource<int>();
+            var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             var puback = await PublishAsync($"$iothub/twin/PATCH/properties/reported/?$rid={lastRid++}", payload);
             if (puback?.ReasonCode == MqttClientPublishReasonCode.Success)
             {
@@ -261,7 +261,7 @@ namespace Rido.IoTHubClient
             {
                 patch_cb = s => tcs.TrySetException(new ApplicationException($"Error '{puback.ReasonCode}' publishing twin PATCH: {s}"));
             }
-            return tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(twinOperationTimeoutSeconds)).Result;
+            return await tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(twinOperationTimeoutSeconds));
         }
 
         public async Task CloseAsync()

--- a/Rido.IoTHubClient/HubMqttClient.cs
+++ b/Rido.IoTHubClient/HubMqttClient.cs
@@ -28,6 +28,7 @@ namespace Rido.IoTHubClient
 
         IMqttClient mqttClient;
         static Timer timerTokenRenew;
+        const int twinOperationTimeoutSeconds = 5;
 
         static Action<string> twin_cb;
         static Action<int> patch_cb;
@@ -245,7 +246,7 @@ namespace Rido.IoTHubClient
             {
                 twin_cb = s => tcs.TrySetException(new ApplicationException($"Error '{puback.ReasonCode}' publishing twin GET: {s}"));
             }
-            return tcs.Task.Result;
+            return tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(twinOperationTimeoutSeconds)).Result;
         }
 
         public async Task<int> UpdateTwinAsync(object payload)
@@ -260,7 +261,7 @@ namespace Rido.IoTHubClient
             {
                 patch_cb = s => tcs.TrySetException(new ApplicationException($"Error '{puback.ReasonCode}' publishing twin PATCH: {s}"));
             }
-            return tcs.Task.Result;
+            return tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(twinOperationTimeoutSeconds)).Result;
         }
 
         public async Task CloseAsync()

--- a/Rido.IoTHubClient/TaskTimeoutExtension.cs
+++ b/Rido.IoTHubClient/TaskTimeoutExtension.cs
@@ -7,22 +7,13 @@ namespace Rido.IoTHubClient
 {
     public static class TaskTimeoutExtension
     {
-        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout)
+        public static async Task<T> TimeoutAfter<T>(this Task<T> source, TimeSpan timeout)
         {
-            using (var timeoutCancellationTokenSource = new CancellationTokenSource())
+            if (await Task.WhenAny(source,Task.Delay(timeout)) != source)
             {
-                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
-                if (completedTask == task)
-                {
-                    timeoutCancellationTokenSource.Cancel();
-                    return await task;
-                }
-                else
-                {
-                    throw new TimeoutException($"{nameof(TimeoutAfter)}: The operation has timed out after {timeout:mm\\:ss}");
-                }
+                throw new TimeoutException();
             }
-
+            return await source;
         }
     }
 }

--- a/Rido.IoTHubClient/TaskTimeoutExtension.cs
+++ b/Rido.IoTHubClient/TaskTimeoutExtension.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rido.IoTHubClient
+{
+    public static class TaskTimeoutExtension
+    {
+        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout)
+        {
+            using var timeoutCancellationTokenSource = new CancellationTokenSource();
+            var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
+            if (completedTask == task)
+            {
+                timeoutCancellationTokenSource.Cancel();
+                return await task;
+            }
+            else
+            {
+                throw new TimeoutException($"{nameof(TimeoutAfter)}: The operation has timed out after {timeout:mm\\:ss}");
+            }
+
+        }
+    }
+}

--- a/Rido.IoTHubClient/TaskTimeoutExtension.cs
+++ b/Rido.IoTHubClient/TaskTimeoutExtension.cs
@@ -9,16 +9,18 @@ namespace Rido.IoTHubClient
     {
         public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout)
         {
-            using var timeoutCancellationTokenSource = new CancellationTokenSource();
-            var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
-            if (completedTask == task)
+            using (var timeoutCancellationTokenSource = new CancellationTokenSource())
             {
-                timeoutCancellationTokenSource.Cancel();
-                return await task;
-            }
-            else
-            {
-                throw new TimeoutException($"{nameof(TimeoutAfter)}: The operation has timed out after {timeout:mm\\:ss}");
+                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
+                if (completedTask == task)
+                {
+                    timeoutCancellationTokenSource.Cancel();
+                    return await task;
+                }
+                else
+                {
+                    throw new TimeoutException($"{nameof(TimeoutAfter)}: The operation has timed out after {timeout:mm\\:ss}");
+                }
             }
 
         }

--- a/sample-device/ProgramV1Topics.cs
+++ b/sample-device/ProgramV1Topics.cs
@@ -21,7 +21,7 @@ namespace sample_device
 
             //string modelId = "dtmi:com:demos;1";
             //var client = await HubMqttClient.CreateWithClientCertsAsync("rido.azure-devices.net","../../../../.certs/devx1.pfx", "1234", modelId);
-            var client = await HubMqttClient.CreateFromConnectionStringAsync(Environment.GetEnvironmentVariable("csm"));
+            var client = await HubMqttClient.CreateFromConnectionStringAsync(Environment.GetEnvironmentVariable("cs"));
 
             Console.WriteLine();
             Console.WriteLine(client.ConnectionSettings);


### PR DESCRIPTION
This PR adds a Task.TimeoutAfter extension to avoid hangs when callbacks are not received
Defaults to 5s.